### PR TITLE
LD_LIBRARY_PATH for linux

### DIFF
--- a/trt_paths.py
+++ b/trt_paths.py
@@ -30,6 +30,11 @@ def set_paths():
     assert trt_path is not None, "Was not able to find TensorRT directory. Looked in: " + ", ".join(looked_in)
 
     trt_lib_path = os.path.join(trt_path, "lib")
+    if "LD_LIBRARY_PATH" in os.environ:
+        os.environ["LD_LIBRARY_PATH"] = f'{trt_lib_path}:{os.environ["LD_LIBRARY_PATH"]}'
+    elif os.name == 'posix':
+        os.environ["LD_LIBRARY_PATH"] = trt_lib_path
+
     if trt_lib_path not in os.environ['PATH']:
         os.environ['PATH'] = os.environ['PATH'] + os.pathsep + trt_lib_path
 


### PR DESCRIPTION
This fixes
`Uncaught exception detected: Unable to open library: libnvinfer_plugin.so.8 due to libnvinfer_plugin.so.8: cannot open shared object file: No such file or directory`
on linux

I can't confirm whether this will do something stupid to a windows machine, and i also haven't tested what happens if LD_LIBRARY_PATH isn't set because it always is set for me because of "cv2" package in venv