### PR TITLE
Add a batch mode + Conversion limit calculation

### DIFF
--- a/export_trt.py
+++ b/export_trt.py
@@ -1,7 +1,8 @@
 import os.path
 
 
-def get_trt_command(trt_filename, onnx_filename, min_bs, max_bs, min_token_count, max_token_count, min_width, max_width, min_height, max_height, use_fp16, trt_extra_args):
+def get_trt_command(trt_filename, onnx_filename, min_bs, max_bs, min_token_count, max_token_count, min_width, max_width, min_height, max_height, use_fp16, trt_extra_args, batch_run=False, batch_directory=""):
+    
     for val, name in zip([min_width, max_width, min_height, max_height], ["min_width", "max_width", "min_height", "max_height"]):
         assert val % 64 == 0, name + ' must be a multiple of 64'
 

--- a/export_trt.py
+++ b/export_trt.py
@@ -1,7 +1,7 @@
 import os.path
 
 
-def get_trt_command(trt_filename, onnx_filename, min_bs, max_bs, min_token_count, max_token_count, min_width, max_width, min_height, max_height, use_fp16, trt_extra_args, batch_run=False, batch_directory=""):
+def get_trt_command(trt_filename, onnx_filename, min_bs, max_bs, min_token_count, max_token_count, min_width, max_width, min_height, max_height, use_fp16, trt_extra_args):
     
     for val, name in zip([min_width, max_width, min_height, max_height], ["min_width", "max_width", "min_height", "max_height"]):
         assert val % 64 == 0, name + ' must be a multiple of 64'

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -7,7 +7,6 @@ import trt_paths
 from modules import script_callbacks, paths_internal, shared
 import gradio as gr
 
-
 import export_onnx
 import export_trt
 from modules.call_queue import wrap_gradio_gpu_call
@@ -26,7 +25,7 @@ def export_unet_to_onnx(filename, opset, batch_run, batch_directory):
         print(f"--Batch Models mode--")
         
         # Check if 'Unet-onnx' directory exists and create it if not
-        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-onnx")        
+        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-onnx")
         os.makedirs(unet_onnx_path, exist_ok=True)
     
         onnx_files = os.listdir(os.path.join(paths_internal.models_path, "Unet-onnx"))
@@ -47,28 +46,32 @@ def export_unet_to_onnx(filename, opset, batch_run, batch_directory):
         # Exit if no files to process
         if not onnx_files_to_process:
             print("No files to convert...\nPlease uncheck the 'Run Batch' checkbox or use a folder containing models.")
-            return "No files to convert... Stopping the conversion...", ''
+            return
         # Process files
-        for file in onnx_files_to_process:
+        for i, file in enumerate(onnx_files_to_process):
             print(f"Converting model file: {file}")  # Debug line
             modelname = os.path.splitext(file)[0] + ".onnx"
-            onnx_filename = os.path.join(unet_onnx_path, modelname)            
+            onnx_filename = os.path.join(unet_onnx_path, modelname)
             print(f"Target ONNX filename: {onnx_filename}\n")  # Debug line
             
             export_onnx.export_current_unet_to_onnx(onnx_filename, opset)
-
-        return f'Batch conversion completed for files in {batch_directory}', ''
+            
+        # Ending message
+        print(f'Batch conversion completed for files in {batch_directory}')
+        return
     # Single mode
     else:
         print(f"--Single Model mode--")
         if not filename:
             modelname = shared.sd_model.sd_checkpoint_info.model_name + ".onnx"
-            filename = os.path.join(batch_directory, modelname)
-        print(f"Target ONNX filename: {filename}\n")  # Debug line
+            onnx_filename = os.path.join(unet_onnx_path, modelname)
+        print(f"Target ONNX filename: {onnx_filename}\n")  # Debug line
         
-        export_onnx.export_current_unet_to_onnx(filename, opset)
+        export_onnx.export_current_unet_to_onnx(onnx_filename, opset)
 
-        return f'Done! Model saved as {filename}', ''
+        # Ending message
+        print(f'Done! Model saved as {filename}')
+        return
 
 
 def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *args):
@@ -83,7 +86,7 @@ def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *ar
         print(f"--Batch Models mode--")
         
         # Check if 'Unet-trt' directory exists and create it if not
-        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-trt")        
+        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-trt")
         os.makedirs(unet_onnx_path, exist_ok=True)
         
         trt_files = os.listdir(os.path.join(paths_internal.models_path, "Unet-trt"))
@@ -104,7 +107,7 @@ def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *ar
         # Exit if no files to process
         if not trt_files_to_process:
             print("No files to convert...\nPlease uncheck the 'Run Batch' checkbox or use a folder containing models.")
-            return "No files to convert. Stopping the conversion...", ''
+            return
         # Process files
         for file in trt_files_to_process:
             onnx_file = os.path.join(batch_directory, file)
@@ -116,7 +119,9 @@ def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *ar
             print(f"Target TRT filename: {trt_filename}\n")  # Debug line
             command = export_trt.get_trt_command(trt_filename, onnx_file, *args)
             launch.run(command, live=True)
-        return f'Batch conversion completed for files in {batch_directory}', ''
+        # Ending message
+        print(f'Batch conversion completed for files in {batch_directory}')
+        return
     # Single mode
     else:
         print(f"--Single Model mode--")
@@ -125,7 +130,9 @@ def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *ar
         command = export_trt.get_trt_command(filename, onnx_filename, *args)
         launch.run(command, live=True)
 
-        return f'Done! Saved as {filename}', ''
+        # Ending message
+        print(f'Done! Model saved as {filename}')
+        return
 
 
 def get_trt_filename(filename, onnx_filename, batch_run=False, *args):

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -19,6 +19,7 @@ def export_unet_to_onnx(filename, opset, batch_run, batch_directory):
     if not batch_directory:
         batch_directory = os.path.join(paths_internal.models_path, "Stable-diffusion")
     if batch_run:
+        filename = ""
         print(f"--Batch Models mode--")  # Debug line
         
         # Check if 'Unet-onnx' directory exists and create it if not
@@ -67,10 +68,11 @@ def convert_onnx_to_trt(filename, onnx_filename, batch_run, batch_directory, *ar
     if not batch_directory:
         batch_directory = os.path.join(paths_internal.models_path, "Unet-onnx") 
     if batch_run:
+        onnx_filename = ""
         print(f"--Batch Models mode--")  # Debug line
         
-        # Check if 'Unet-onnx' directory exists and create it if not
-        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-onnx")        
+        # Check if 'Unet-trt' directory exists and create it if not
+        unet_onnx_path = os.path.join(paths_internal.models_path, "Unet-trt")        
         os.makedirs(unet_onnx_path, exist_ok=True)
         
         trt_files = os.listdir(os.path.join(paths_internal.models_path, "Unet-trt"))

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -42,7 +42,7 @@ def export_unet_to_onnx(filename, opset, batch_run, batch_directory):
         for file in onnx_files_to_process:
             print(f"Converting model file: {file}")  # Debug line
             modelname = os.path.splitext(file)[0] + ".onnx"
-            onnx_filename = os.path.join(batch_directory, modelname)            
+            onnx_filename = os.path.join(unet_onnx_path, modelname)            
             print(f"Target ONNX filename: {onnx_filename}")  # Debug line
             
             export_onnx.export_current_unet_to_onnx(onnx_filename, opset)


### PR DESCRIPTION
Hey, 

as mentionned here : https://github.com/AUTOMATIC1111/stable-diffusion-webui-tensorrt/issues/30

A batch mode would be appreciated.

Obviously not a python expert, lol. 

Add a checkbox to activate batch mode.
Add a field for a folder containing models to convert. Both tab.
_EDIT_: Using "models/Stable-diffusion" and "models/Unet-onnx" as default, if leaved empty.
Add some basic logging into the console, kind of blind right now, wondering if it's dead or alive when converting to onnx, and what is going on.
_EDIT_: Add a Calculation to display the limit allowed for ONNX to TRT conversion. Should still work as the limit is going up, eventually, as well.

Screen for the 'Convert to ONNX' tab :

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui-tensorrt/assets/22177081/9a158088-c4d6-4fbb-9f47-b086fe472409)


![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui-tensorrt/assets/22177081/a48402fc-5460-4457-b786-890f2763b8e1)
<br>

Screen for the 'Convert ONNX to TensorRT' tab  : 

![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui-tensorrt/assets/22177081/503f4798-a156-4d1a-8a2e-d217a4234992)


![image](https://github.com/AUTOMATIC1111/stable-diffusion-webui-tensorrt/assets/22177081/a6d39860-b230-411c-8bfe-5114fb42a6e7)


It will process all the files in the folder as well. I mean, it worked for me, lol.
<br>

Cheers ! 🥂
